### PR TITLE
Replace dependency `PySide6` to `PySide6-Essentials`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -357,41 +357,6 @@ docs = ["furo (>=2024.5.6)", "sphinx-autodoc-typehints (>=2.2.1)"]
 testing = ["covdefaults (>=2.3)", "pytest (>=8.2.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "setuptools (>=70.1)"]
 
 [[package]]
-name = "pyside6"
-version = "6.7.2"
-description = "Python bindings for the Qt cross-platform application and UI framework"
-optional = false
-python-versions = "<3.13,>=3.9"
-files = [
-    {file = "PySide6-6.7.2-cp39-abi3-macosx_11_0_universal2.whl", hash = "sha256:602debef9ec159b0db48f83b38a0e43e2dad3961f7d99f708d98620f04e9112b"},
-    {file = "PySide6-6.7.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:15e7696a09072ee977f6e6179ab1e48184953df8417bcaa83cfadf0b79747242"},
-    {file = "PySide6-6.7.2-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:6e0acb471535de303f56e3077aa86f53496b4de659b99ecce80520bcee508a63"},
-    {file = "PySide6-6.7.2-cp39-abi3-win_amd64.whl", hash = "sha256:f73ae0de77d67f51ca3ce8207b12d3a5fa0107d3d5b6e4aeb3b53ee842b0927a"},
-]
-
-[package.dependencies]
-PySide6-Addons = "6.7.2"
-PySide6-Essentials = "6.7.2"
-shiboken6 = "6.7.2"
-
-[[package]]
-name = "pyside6-addons"
-version = "6.7.2"
-description = "Python bindings for the Qt cross-platform application and UI framework (Addons)"
-optional = false
-python-versions = "<3.13,>=3.9"
-files = [
-    {file = "PySide6_Addons-6.7.2-cp39-abi3-macosx_11_0_universal2.whl", hash = "sha256:90b995efce61058d995c603ea480a9a3054fe8206739dcbc273fc3b53d40650f"},
-    {file = "PySide6_Addons-6.7.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:94b9bf6a2a4a7ac671e1776633e50d51326c86f4184f1c6e556f4dd5498fd52a"},
-    {file = "PySide6_Addons-6.7.2-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:22979b1aa09d9cf1d7a86c8a9aa0cb4791d6bd1cc94f96c5b6780c5ef8a9e34e"},
-    {file = "PySide6_Addons-6.7.2-cp39-abi3-win_amd64.whl", hash = "sha256:ebf549eb25998665d8e4ec24014fbbd37bebc5ecdcb050b34db1e1c03e1bf81d"},
-]
-
-[package.dependencies]
-PySide6-Essentials = "6.7.2"
-shiboken6 = "6.7.2"
-
-[[package]]
 name = "pyside6-essentials"
 version = "6.7.2"
 description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
@@ -648,4 +613,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "f8f79159558ac52e8e8122cbcf31a3edfd7fa7c9a7890490a41a4979c5dbb31b"
+content-hash = "1cb2304fa08cc84381ae62dd8a068e9b4afe6eb1c261ece5b6be36975e7f1f2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "expedite"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Simple encrypted file transfer service"
 authors = ["Akashdeep Dhar <akashdeep.dhar@gmail.com>"]
 license = "GPL-3.0-or-later"
@@ -12,14 +12,22 @@ documentation = "https://github.com/gridhead/expedite/blob/main/README.md"
 keywords = [""]
 classifiers= [
     "Development Status :: 4 - Beta",
+    "Environment :: X11 Applications :: Qt",
     "Intended Audience :: Developers",
+    "Intended Audience :: End Users/Desktop",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
+    "Topic :: Communications",
+    "Topic :: Communications :: File Sharing",
+    "Topic :: Internet",
     "Topic :: Security",
     "Topic :: Security :: Cryptography",
     "Topic :: System :: Networking",
+    "Topic :: Utilities"
 ]
 
 [tool.poetry.dependencies]
@@ -28,7 +36,7 @@ websockets = "^12.0"
 click = "^8.1.7"
 tqdm = "^4.66.4"
 cryptography = "^42.0.8"
-pyside6 = "^6.7.2"
+pyside6-essentials = "^6.7.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3 || ^8.0.0"


### PR DESCRIPTION
Add more classifiers for people to easily discover the PyPI distribution

This should reduce the storage size of the final application package